### PR TITLE
Update README.md installation instructions for python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Prerequisites:
 
 Create an anaconda environment:
 ```
-conda create -n simpler_env python=3.10 (any version above 3.10 should be fine)
+conda create -n simpler_env python=3.10 (3.10 or 3.11)
 conda activate simpler_env
 ```
 


### PR DESCRIPTION
Update README.md installation instructions as sapien 2.2.2 is not available for python 3.12

sapien 2.2.2 is required by [Maniskill](https://github.com/simpler-env/ManiSkill2_real2sim/blob/ef7a4d4fdf4b69f2c2154db5b15b9ac8dfe10682/requirements.txt#L5) but is [not available for python 3.12](https://pypi.org/project/sapien/#files)